### PR TITLE
Add brightcove short URL pattern to embed.ly urls

### DIFF
--- a/lib/oembed/providers/embedly_urls.yml
+++ b/lib/oembed/providers/embedly_urls.yml
@@ -84,6 +84,7 @@
 - http://barelydigital.com/episode/*
 - http://barelypolitical.com/*/episode/*
 - http://barelypolitical.com/episode/*
+- http://bcove.me/*
 - http://bigthink.com/ideas/*
 - http://bigthink.com/series/*
 - http://blip.tv/*/*


### PR DESCRIPTION
Hey - the embed.ly URLs was missing this brightcove pattern.  