### PR TITLE
Force https on youtube, close #33

### DIFF
--- a/lib/oembed/providers.rb
+++ b/lib/oembed/providers.rb
@@ -136,7 +136,7 @@ module OEmbed
     #     OEmbed::Providers::Youtube.endpoint += "?iframe=0"
     # * To require https embed code
     #     OEmbed::Providers::Youtube.endpoint += "?scheme=https"
-    Youtube = OEmbed::Provider.new("http://www.youtube.com/oembed")
+    Youtube = OEmbed::Provider.new("http://www.youtube.com/oembed?scheme=https")
     Youtube << "http://*.youtube.com/*"
     Youtube << "https://*.youtube.com/*"
     Youtube << "http://*.youtu.be/*"


### PR DESCRIPTION
This will request youtube content using https, allowing youtube embedding in https without any problem even with the "block mixed content" feature in the browser (Now enabled by default in Firefox since the version 23).

It also increases security for the non https pages.