### PR TITLE
Use https version of the Vimeo API endpoint

### DIFF
--- a/lib/oembed/providers.rb
+++ b/lib/oembed/providers.rb
@@ -174,7 +174,7 @@ module OEmbed
 
     # Provider for vimeo.com
     # http://developer.vimeo.com/apis/oembed
-    Vimeo = OEmbed::Provider.new("http://vimeo.com/api/oembed.{format}")
+    Vimeo = OEmbed::Provider.new("https://vimeo.com/api/oembed.{format}")
     Vimeo << "http://*.vimeo.com/*"
     Vimeo << "https://*.vimeo.com/*"
     add_official_provider(Vimeo)


### PR DESCRIPTION
Looks like it mirrors the scheme used there now.