### PR TITLE
Update Instagram provider to accept https:// URLs

### DIFF
--- a/lib/oembed/providers.rb
+++ b/lib/oembed/providers.rb
@@ -197,6 +197,8 @@ module OEmbed
     Instagram = OEmbed::Provider.new("http://api.instagram.com/oembed", :json)
     Instagram << "http://instagr.am/p/*"
     Instagram << "http://instagram.com/p/*"
+    Instagram << "https://instagr.am/p/*"
+    Instagram << "https://instagram.com/p/*"
     add_official_provider(Instagram)
 
     # Provider for slideshare.net


### PR DESCRIPTION
Instagram now uses https URLs everywhere but these were not handled by the Instagram provider.