### PR TITLE
Add HTTPS scheme to Flickr

### DIFF
--- a/lib/oembed/providers.rb
+++ b/lib/oembed/providers.rb
@@ -145,8 +145,9 @@ module OEmbed
 
     # Provider for flickr.com
     # http://developer.yahoo.com/blogs/ydn/posts/2008/05/oembed_embeddin/
-    Flickr = OEmbed::Provider.new("http://www.flickr.com/services/oembed/")
+    Flickr = OEmbed::Provider.new("https://www.flickr.com/services/oembed/")
     Flickr << "http://*.flickr.com/*"
+    Flickr << "https://*.flickr.com/*"
     add_official_provider(Flickr)
 
     # Provider for viddler.com


### PR DESCRIPTION
* Match https* Flickr URL
* Use https oembed endpoint that Flickr now enforces

```
$ curl --verbose http://www.flickr.com/services/oembed?url=http://flickr.com/photos/bees/2362225867/
* Hostname was NOT found in DNS cache
*   Trying 98.138.81.73...
* Connected to www.flickr.com (98.138.81.73) port 80 (#0)
> GET /services/oembed?url=http://flickr.com/photos/bees/2362225867/ HTTP/1.1
> User-Agent: curl/7.37.1
> Host: www.flickr.com
> Accept: */*
> 
< HTTP/1.1 301 Moved Permanently
< Date: Sat, 25 Apr 2015 14:17:42 GMT
< Content-Type: text/html; charset=UTF-8
< Content-Length: 0
< P3P: policyref="http://info.yahoo.com/w3c/p3p.xml", CP="CAO DSP COR CUR ADM DEV TAI PSA PSD IVAi IVDi CONi TELo OTPi OUR DELi SAMi OTRi UNRi PUBi IND PHY ONL UNI PUR FIN COM NAV INT DEM CNT STA POL HEA PRE LOC GOV"
< Set-Cookie: xb=652738; expires=Tue, 25-Apr-2017 14:17:42 GMT; path=/; domain=.flickr.com
< Location: https://www.flickr.com/services/oembed?url=http://flickr.com/photos/bees/2362225867/
```