### PR TITLE
Match www Instagram subdomain

### DIFF
--- a/lib/oembed/providers.rb
+++ b/lib/oembed/providers.rb
@@ -199,8 +199,10 @@ module OEmbed
     Instagram = OEmbed::Provider.new("https://api.instagram.com/oembed", :json)
     Instagram << "http://instagr.am/p/*"
     Instagram << "http://instagram.com/p/*"
+    Instagram << "http://www.instagram.com/p/*"
     Instagram << "https://instagr.am/p/*"
     Instagram << "https://instagram.com/p/*"
+    Instagram << "https://www.instagram.com/p/*"
     add_official_provider(Instagram)
 
     # Provider for slideshare.net


### PR DESCRIPTION
Looks like Instagram is directing all traffic to its www subdomain now:
```sh
$ curl -I https://instagram.com/p/-wN1PMSB6_/
HTTP/1.1 301 MOVED PERMANENTLY
Location: https://www.instagram.com/p/-wN1PMSB6_/
```

Before this change:
```ruby
>> OEmbed::Providers::Instagram.get("https://www.instagram.com/p/-wN1PMSB6_/")
OEmbed::NotFound: No embeddable content at 'https://www.instagram.com/p/-wN1PMSB6_/'
```
After:
```ruby
>> OEmbed::Providers::Instagram.get("https://www.instagram.com/p/-wN1PMSB6_/")
=> #<OEmbed::Response::Rich:0x007fb877a98468 @fields={"provider_url"=>"https://www.instagram.com", "media_id"=>"1130464339519086271_904614", ...
```